### PR TITLE
增加超级播放器对外的接口

### DIFF
--- a/Demo/superplayerkit/build.gradle
+++ b/Demo/superplayerkit/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 //    implementation project(':liteav_sdk')
     implementation project(':common')
-    implementation rootProject.ext.liteavSdk
+    api rootProject.ext.liteavSdk
     implementation 'com.github.ctiao:DanmakuFlameMaster:0.5.3'
 
     implementation 'androidx.appcompat:appcompat:1.0.0'

--- a/Demo/superplayerkit/src/main/java/com/tencent/liteav/demo/superplayer/SuperPlayerView.java
+++ b/Demo/superplayerkit/src/main/java/com/tencent/liteav/demo/superplayer/SuperPlayerView.java
@@ -34,6 +34,7 @@ import android.widget.Toast;
 
 import com.cloud.tencent.liteav.demo.comon.TUIBuild;
 import com.tencent.liteav.demo.common.utils.IntentUtils;
+import com.tencent.liteav.demo.superplayer.model.ISuperPlayerListener;
 import com.tencent.liteav.demo.superplayer.model.SuperPlayer;
 import com.tencent.liteav.demo.superplayer.model.SuperPlayerImpl;
 import com.tencent.liteav.demo.superplayer.model.SuperPlayerObserver;
@@ -104,6 +105,7 @@ public class SuperPlayerView extends RelativeLayout {
     private boolean                    isCallResume = false;            //resume方法时候被调用，在预加载模式使用
     private LinearLayout               mDynamicWatermarkLayout;
     private DynamicWatermarkView       mDynamicWatermarkView;
+	private ISuperPlayerListener mSuperPlayerListener;
 
     public SuperPlayerView(Context context) {
         super(context);
@@ -377,6 +379,18 @@ public class SuperPlayerView extends RelativeLayout {
      */
     public void setPlayerViewCallback(OnSuperPlayerViewCallback callback) {
         mPlayerViewCallback = callback;
+    }
+
+    /**
+     * 设置超级播放器中点播播放器和直播播放器的回调
+     *
+     * @param superPlayerListener
+     */
+    public void setSuperPlayerListener(ISuperPlayerListener superPlayerListener) {
+        mSuperPlayerListener = superPlayerListener;
+        if(mSuperPlayer != null) {
+            mSuperPlayer.setSuperPlayerListener(mSuperPlayerListener);
+        }
     }
 
     /**
@@ -1165,4 +1179,15 @@ public class SuperPlayerView extends RelativeLayout {
         mSuperPlayer.setLoop(b);
     }
 
+    public void pause() {
+        mSuperPlayer.pause();
+    }
+
+    public void resume() {
+        mSuperPlayer.resume();
+    }
+
+    public void stop() {
+        mSuperPlayer.stop();
+    }
 }

--- a/Demo/superplayerkit/src/main/java/com/tencent/liteav/demo/superplayer/model/ISuperPlayerListener.java
+++ b/Demo/superplayerkit/src/main/java/com/tencent/liteav/demo/superplayer/model/ISuperPlayerListener.java
@@ -1,0 +1,13 @@
+package com.tencent.liteav.demo.superplayer.model;
+
+import android.os.Bundle;
+
+import com.tencent.rtmp.TXVodPlayer;
+
+public interface ISuperPlayerListener {
+    public void onVodPlayEvent(final TXVodPlayer player, final int event, final Bundle param);
+    public void onVodNetStatus(final TXVodPlayer player, final Bundle status);
+    
+    public void onLivePlayEvent(final int event, final Bundle param);
+    public void onLiveNetStatus(final Bundle status);
+}

--- a/Demo/superplayerkit/src/main/java/com/tencent/liteav/demo/superplayer/model/SuperPlayer.java
+++ b/Demo/superplayerkit/src/main/java/com/tencent/liteav/demo/superplayer/model/SuperPlayer.java
@@ -119,6 +119,12 @@ public interface SuperPlayer {
     void setObserver(SuperPlayerObserver observer);
 
     /**
+     * 设置超级播放器中点播事件和直播事件的回调
+     * @param superPlayerListener
+     */
+    void setSuperPlayerListener(ISuperPlayerListener superPlayerListener);
+
+    /**
      * 设置是否循环
      * @param isLoop true循环，false不循环
      */

--- a/Demo/superplayerkit/src/main/java/com/tencent/liteav/demo/superplayer/model/SuperPlayerImpl.java
+++ b/Demo/superplayerkit/src/main/java/com/tencent/liteav/demo/superplayer/model/SuperPlayerImpl.java
@@ -55,6 +55,7 @@ public class SuperPlayerImpl implements SuperPlayer, ITXVodPlayListener, ITXLive
     private TXVodPlayConfig            mVodPlayConfig;   // 点播播放器配置
     private TXLivePlayer               mLivePlayer;      // 直播播放器
     private TXLivePlayConfig           mLivePlayConfig;  // 直播播放器配置
+    private ISuperPlayerListener mSuperPlayerListener;
     private SuperPlayerModel           mCurrentModel;  // 当前播放的model
     private SuperPlayerObserver        mObserver;
     private VideoQuality               mVideoQuality;
@@ -138,6 +139,9 @@ public class SuperPlayerImpl implements SuperPlayer, ITXVodPlayListener, ITXLive
             default:
                 break;
         }
+        if(mSuperPlayerListener != null){
+            mSuperPlayerListener.onLivePlayEvent(event, param);
+        }
     }
 
     /**
@@ -147,7 +151,9 @@ public class SuperPlayerImpl implements SuperPlayer, ITXVodPlayListener, ITXLive
      */
     @Override
     public void onNetStatus(Bundle bundle) {
-
+        if(mSuperPlayerListener != null){
+            mSuperPlayerListener.onLiveNetStatus(bundle);
+        }
     }
 
     /**
@@ -204,6 +210,9 @@ public class SuperPlayerImpl implements SuperPlayer, ITXVodPlayListener, ITXLive
             updatePlayerState(SuperPlayerDef.PlayerState.PAUSE);
             onError(SuperPlayerCode.VOD_PLAY_FAIL, param.getString(TXLiveConstants.EVT_DESCRIPTION));
         }
+		if(mSuperPlayerListener != null){
+            mSuperPlayerListener.onVodPlayEvent(player, event, param);
+		}
     }
 
 
@@ -257,7 +266,9 @@ public class SuperPlayerImpl implements SuperPlayer, ITXVodPlayListener, ITXLive
      */
     @Override
     public void onNetStatus(TXVodPlayer player, Bundle bundle) {
-
+        if(mSuperPlayerListener != null){
+            mSuperPlayerListener.onVodNetStatus(player, bundle);
+        }
     }
 
     private void initialize(Context context, TXCloudVideoView videoView) {
@@ -989,6 +1000,11 @@ public class SuperPlayerImpl implements SuperPlayer, ITXVodPlayListener, ITXLive
     @Override
     public void setObserver(SuperPlayerObserver observer) {
         mObserver = observer;
+    }
+
+    @Override
+    public void setSuperPlayerListener(ISuperPlayerListener superPlayerListener) {
+        mSuperPlayerListener = superPlayerListener;
     }
 
     @Override


### PR DESCRIPTION
1,sdk引用方式改为api，使得flutter项目可以include。
2,新增超级播放器pause,resume,stop接口。
3,将点播播放器和直播播放器的接口通过超级播放器暴露出来。